### PR TITLE
Use copyto! and similar to minimize reallocation of memory

### DIFF
--- a/lessons/00_Quick_Julia_Intro.jl
+++ b/lessons/00_Quick_Julia_Intro.jl
@@ -116,7 +116,13 @@ a[2] = 3
 a
 c
 
-# OK, it worked!  If the difference between `a = b` and `a = b.copy()` is unclear, you should read through this again.  This issue will come back to haunt you otherwise.
+# OK, it worked!  If the difference between `a = b` and `a = copy(b)` is unclear, you should read through this again.  This issue will come back to haunt you otherwise.
+
+# Every time we `copy` we create a brand new matrix and have to allocate new memory. Allocating new memory is expensive, especially if we do it repeatedly.
+# To reuse the existing memory we allocated for `c` when copying `a`, we can use `copyto!`.
+# The exclamation mark indicates we are changing one of the arguments, `c` in this case.
+
+copyto!(c, a)
 
 ## Learn More
 

--- a/lessons/01_Step_1.jl
+++ b/lessons/01_Step_1.jl
@@ -112,10 +112,10 @@ pyplot.plot(range(start = 0, stop = 2, length = nx), u);
 # so we'll start by nesting one loop inside the other. Note the use of the nifty `enumerate` function.
 # When we write: `for i in nx` we will iterate through the `u` array.
 
-un = ones(nx) #initialize a temporary array
+un = similar(u) #initialize a temporary array like u of the same type and size
 
 for n in nt  #loop for values of n from 0 to nt, so it will run nt times
-    un = copy(u) ##copy the existing values of u into un
+    copyto!(un, u) ##copy the existing values of u into un
     for (elem, i) in enumerate(nx)
     # for i in 1:length(nx) # Try commenting the previous line and uncommenting this one to see what happens!
         u[i] = un[i] - c * dt / dx * (un[i] - un[i-1])

--- a/lessons/02_Step_2.jl
+++ b/lessons/02_Step_2.jl
@@ -56,14 +56,14 @@ for i in length((.5/Δx):(1/Δx))
       u[i] = 2
 end
 
-uₙ = ones(nₓ) #initialize our placeholder array un, to hold the time-stepped solution
+uₙ = similar(u) #initialize our placeholder array un, to hold the time-stepped solution
 
 # The code snippet below is *unfinished*. We have copied over the line from [Step 1](./01_Step_1.jl)
 # that executes the time-stepping update. Can you edit this code to execute the nonlinear convection instead?
 
 
 for n in nₜ  #iterate through time
-    uₙ = copy(u) ##copy the existing values of u into uₙ
+    copyto!(uₙ, u) ##copy the existing values of u into uₙ
     for i in 1:nₓ  ##now we'll iterate through the u array
     
      ###This is the line from Step 1, copied exactly.  Edit it for our new equation.

--- a/lessons/03_CFL_Condition.jl
+++ b/lessons/03_CFL_Condition.jl
@@ -37,10 +37,10 @@ function  linearconv(nₓ)
     u = ones(nₓ)      #defining a numpy array which is nx elements long with every value equal to 1.
     u[Int.((.5/dx):(1 / dx))] .= 2.0  #setting u = 2 between 0.5 and 1 as per our I.C.s
 
-    uₙ = ones(nₓ) #initializing our placeholder array, un, to hold the values we calculate for the n+1 timestep
+    uₙ = similar(u) #initializing our placeholder array, un, to hold the values we calculate for the n+1 timestep
 
     for n in nₜ #iterate through time
-        uₙ = copy(n) ##copy the existing values of u into un
+        copyto!(uₙ, u) ##copy the existing values of u into un
         for i in 1:nₓ
             u[i] = uₙ[i] - c * dt / dx * (uₙ[i] - uₙ[i-1])
         end
@@ -106,10 +106,10 @@ function linearconv(nₓ)
     u = ones(nx)
     u[indexes] .= 2
 
-    un = ones(nx)
+    un = similar(u)
 
     for n in range(nₜ):  #iterate through time
-        uₙ = copy(u) ##copy the existing values of u into un
+        copyto!(uₙ, u) ##copy the existing values of u into un
         for i in 1:nₓ
             u[i] = uₙ[i] - c * dt / dx * (uₙ[i] - uₙ[i-1])
         end

--- a/lessons/04_Step_3.jl
+++ b/lessons/04_Step_3.jl
@@ -61,14 +61,14 @@ u = ones(nₓ)      #as before, we initialize u with every value equal to 1.
 indexes = Int.((.5/Δx):(1/Δx))
 u[indexes] .= 2 #then set u = 2 between 0.5 and 1 as per our I.C.s
 
-uₙ = ones(nₓ) #initialize our placeholder array un, to hold the time-stepped solution
+uₙ = similar(u) #initialize our placeholder array un, to hold the time-stepped solution
 
-u = numpy.ones(nx)      #a numpy array with nx elements all equal to 1.
-u[int(.5 / dx):int(1 / dx + 1)] = 2  #setting u = 2 between 0.5 and 1 as per our I.C.s
+u = ones(nx)      #a numpy array with nx elements all equal to 1.
+u[Int(.5 / dx):Int(1 / dx + 1)] = 2  #setting u = 2 between 0.5 and 1 as per our I.C.s
 
 
 for n in nₜ  #iterate through time
-    uₙ = copy(u) ##copy the existing values of u into uₙ
+    copyto!(uₙ, u) ##copy the existing values of u into un
     for i in 1:nₓ  ##now we'll iterate through the u array
 
      ###This is the line from Step 1, copied exactly.  Edit it for our new equation.

--- a/lessons/06_Array_Operations_with_NumPy.jl
+++ b/lessons/06_Array_Operations_with_NumPy.jl
@@ -54,7 +54,7 @@ rangey = range(start = 0, stop = 2, length = ny)
 
 ### TODO
 u = ones(ny, nₓ) ##create a 1xn vector of 1's
-uₙ = ones(ny, nₓ)
+uₙ = similar(u)
 
 ###Assign initial conditions
 #We can try the following to start the initial conditions:
@@ -92,7 +92,7 @@ using BenchmarkTools
 
 @btime begin
     for n in 1:nₜ ##loop across number of time steps
-    uₙ = copy(u)
+    copyto!(uₙ, u)
     row, col = size(u)
     for j in 1:row
         for i in 1:col
@@ -150,10 +150,11 @@ end :setup=(u = ones(ny, nx))
 #
 function time1(u, params)
     u = ones(ny, nₓ)
+    uₙ = similar(u)
     (;Δt, Δx, c, nₜ) = params
 
     for n in 1:nₜ ##loop across number of time steps
-    uₙ = copy(u)
+    copyto!(uₙ, u)
             @views u[:,:] .= (uₙ[2:end, 2:end] - (c * Δt / Δx *
                                   (uₙ[2:end, 2:end] - uₙ[2:end, 1:end])) -
                                   (c * Δt / Δy *

--- a/lessons/07_Step_5.jl
+++ b/lessons/07_Step_5.jl
@@ -151,9 +151,10 @@ surf = ax.plot_surface(X, Y, u[:], cmap=cm.viridis)
 # TODO
 u = ones((ny, nx))
 # u[int(.5 / dy):int(1 / dy + 1), int(.5 / dx):int(1 / dx + 1)] = 2
+uₙ = similar(u)
 
 for n in 1:nₜ ##loop across number of time steps
-    uₙ = copy(u)
+    copyto!(uₙ, u)
     row, col = size(u)
     # TODO C vs FORTRAN order
     for j in 2:row
@@ -185,9 +186,10 @@ surf2 = ax.plot_surface(X, Y, u[:], cmap=cm.viridis)
 # TODO timing
 u = ones((ny, nx))
 u[CartesianIndices((rangex, rangey))] .= 2
+uₙ = similar(u)
 
 for n in 1:nₜ ##loop across number of time steps
-    uₙ = copy(u)
+    copyto!(uₙ, u)
     u[2:end, 2:end] = @views (uₙ[2:end, 2:end] - (c * Δt / Δx * (uₙ[2:end, 2:end] - uₙ[2:end, begin:(end-1)])) -
                               (c * Δt / Δy * (uₙ[2:end, 2:end] - uₙ[begin:(end-1), 2:end])))
     u[begin, :] .= 1.0

--- a/lessons/08_Step_6.jl
+++ b/lessons/08_Step_6.jl
@@ -89,13 +89,14 @@ ax.plot_surface(X, Y, u, cmap=cm.viridis, rstride=2, cstride=2)
 ax.set_xlabel('$x$')
 ax.set_ylabel('$y$');
 
-
+un = similar(u)
+vn = similar(v)
 
 # TODO BIKESHED Syntax
 # Possible OffsetArrays.jl example?
 for n in  1:nₜ
-    un = copy(u)
-    vn = copy(v)
+    copyto!(un, u)
+    copyto!(vn, v)
     @views u[begin+1:end, begin+1:end] = (un[begin+1:end, begin+1:end] -
                  (un[begin+1:end, begin+1:end] * c * Δt / Δx * (un[begin+1:end, begin+1:end] - un[begin+1:end, begin:end-1])) -
                   vn[begin+1:end, begin+1:end] * c * Δt / Δy * (un[begin+1:end, begin+1:end] - un[:-1, begin+1:end]))

--- a/lessons/09_Step_7.jl
+++ b/lessons/09_Step_7.jl
@@ -46,8 +46,8 @@ rangex = range(start = 0, stop = 2, length = nₓ)
 rangey = range(start = 0, stop = 2, length = ny)
 indices = CartesianIndices((rangex, rangey))
 
-uₙ = ones(ny, nₓ) ##create a 1xn vector of 1's
-u  = ones(ny, nₓ)
+u = ones(ny, nₓ) ##create a 1xn vector of 1's
+uₙ = similar(u)
 
 # ## Assign initial conditions
 ##set hat function I.C. : u(.5<=x<=1 && .5<=y<=1 ) is 2
@@ -86,9 +86,10 @@ function diffuse(nt)
     rangey = range(start = 0, stop = 2, length = ny)
     indices = CartesianIndices((rangex, rangey))
     u[indices] = 2.0
+    un = similar(u)
 
     for n in 1:nt
-        un = copy(n)
+        copyto!(un, u)
         # TODO check indexing
         u[2:end, 2:end] = (un[2:end,2:end] +
                         nu * Δt / Δx^2 *

--- a/lessons/10_Step_8.jl
+++ b/lessons/10_Step_8.jl
@@ -99,10 +99,13 @@ ax.plot_surface(X, Y, v[:], cmap=cm.viridis, rstride=1, cstride=1)
 ax.set_xlabel('$x$')
 ax.set_ylabel('$y$');
 
+un = similar(u)
+vn = similar(v)
+
 # TODO fix variable names, make as function
 for n in 1:nₜ
-    un = u.copy()
-    vn = v.copy()
+    copyto!(un, u)
+    copyto!(vn, v)
 
     u[2:end, 2:end] = @views (un[2:end, 2:end] -
                      dt / dx * un[2:end, 2:end] *


### PR DESCRIPTION
This is just a change to use `similar` to create `u_n` as well `copyto!` rather than `copy`.

Using `similar` does not force the filling of memory with `1`s. It just allocates the memory and keeps whatever might be there.

`copyto!` reuses the existing allocated memory rather than allocating more memory. Additionally, in later iterations this would allow us to reuse views of `u_n` without having to create them in the `for` loop. For example see my gist:
https://gist.github.com/mkitti/b34206ee3dcd4699ed4062d986d61206